### PR TITLE
add pyaml as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Tested only on Mac (for now).
 
 * Python packages
     * subprocess32
+    * pyaml
 
 **oathtool** should be available on the PATH
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 
     keywords='oathtool wrapper',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    install_requires=['subprocess32'],
+    install_requires=['subprocess32', 'pyaml'],
 
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This was required for me to run it on Arch.