### PR TITLE
Update to Python 3, add holdoff argument to config, and fix issue with piping output

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ The script will read these values from a config file sourced from, by default, *
       aws-account-dev: XQYNZOIA4PWCTJCB9654EQP5LUIP23BOW6J5ZIRZZSDHK24AUEDUSCONP3KQQY4N
       aws-account-prod: 57QPXJFJ4D2ILQBRZGSHKAZCJ2Y46C52FGVSZRYMY7UMWTIQI6I3GOJQZ4VJN2R4
 
+Additionally, the following configuration options are supported in the **~/.otp-secrets.yaml** file:
+
+* `holdoff`: Specify a different holdoff value to wait for the next code
+* `use_clipboard`: Disable putting the code on the clipboard
+
+## Autocompletion
+
+Autocompletion support can be added through use of the `-t` flag.
+
+For zsh support, add the following to your `.zshrc` file:
+
+    compdef _otp otp
+    _otp() {
+      compadd `otp -t`
+    }
 ## Building
 
 Activate the pipenv with the `--dev` flag
@@ -84,4 +99,3 @@ Upload to PyPI
 2-Factor is meant to provide an extra layer of account security and this tool does not exactly promote that concept. You should be responsible for taking reasonable steps to protect your secrets file, and perhaps this is not the ideal 2-Factor solution for your most important accounts.
 
 I take no responsibility if you lose accounts through using this tool.
-

--- a/py_oathtool/otp.py
+++ b/py_oathtool/otp.py
@@ -118,6 +118,7 @@ def main():
                     try:
                         program = ['xclip', '-selection', 'clipboard'] if platform.system() == 'Linux' else ['pbcopy']
                         process = subprocess.Popen(program, stdin=subprocess.PIPE)
+
                         process.stdin.write(totp)
                         process.stdin.close()
                     except subprocess.CalledProcessError, err:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """A setuptools based setup module.
 
 See:
@@ -19,7 +21,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='py_oathtool',
-    version='1.0.2',
+    version='1.1.0',
     description='A python wrapper around oathtool',
     long_description=long_description,
     url='https://github.com/matalo33/py_oathtool',
@@ -35,8 +37,7 @@ setup(
         'Topic :: System :: Systems Administration',
         'Topic :: Utilities',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
     ],
 
     keywords='oathtool wrapper',


### PR DESCRIPTION
A few changes:

* Fixes #6 by upgrading to Python 3
* Add an argument to the config file for changing the holdoff value. I found that 5 seconds was excessive for a quick copy and paste to another window since that would only take about a second. Having it configurable is nice.
* Only put the code on the clipboard if a tty. Otherwise, piping the output through another program (for example, to remove the time remaining for scripting) would result in the program hanging.
* Adds an example of how to use the autocomplete feature with zsh

Let me know if this is too much for a single PR and I can break it up. I originally wanted to fix the piping issue and got a bit carried away with other stuff. :)