### PR TITLE
Add Wayland support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Tested only on Mac (for now).
 
 **oathtool** should be available on the PATH
 
-* (Mac) `brew install oath-toolkit`
+* Mac: `brew install oath-toolkit`
+* Linux: `xclip` for clipboard support
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ Developed and tested mainly on MacOS.
 ## Dependencies
 
 * Python packages
-    * subprocess32
+    * subprocess
     * pyaml
 
 **oathtool** should be available on the PATH
 
 * Mac: `brew install oath-toolkit`
-
-Clipboard support on MacOS is supported by `pbcopy` which is installed by default. For Linux install `xclip`
+* Linux: `xclip` for X11 or `wl-copy` for Wayland for clipboard support
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Developed and tested mainly on MacOS.
 **oathtool** should be available on the PATH
 
 * Mac: `brew install oath-toolkit`
-* Linux: `xclip` for X11 or `wl-copy` for Wayland for clipboard support
+* Linux: `xclip` on X11 or `wl-copy` on Wayland for clipboard support
+
+Clipboard support on MacOS is supported by `pbcopy` which is installed by default.
 
 ## Usage
 

--- a/py_oathtool/otp.py
+++ b/py_oathtool/otp.py
@@ -122,7 +122,14 @@ def main():
                 # Try and put it on the clipboard unless disabled and printing to a terminal
                 if ('use_clipboard' not in otpSecrets or otpSecrets['use_clipboard'] != False) and sys.stdout.isatty():
                     try:
-                        program = ['xclip', '-selection', 'clipboard'] if platform.system() == 'Linux' else ['pbcopy']
+                        program = None
+
+                        if platform.system() == 'Linux':
+                            # If on Linux determine if using X11 or Wayland
+                            program = ['wl-copy'] if 'WAYLAND_DISPLAY' in os.environ else ['xclip', '-selection', 'clipboard']
+                        else:
+                            program = ['pbcopy']
+
                         process = subprocess.Popen(program, stdin=subprocess.PIPE)
 
                         process.stdin.write(totp)


### PR DESCRIPTION
`xclip` is an X11 utility which doesn't work if using Wayland on Linux. For clipboard functionality to work, it's necessary to call the equivalent Wayland utility, `wl-copy`. This patch changes the Linux behavior to use the relevant copy command for X11 or Wayland depending on which is being used.